### PR TITLE
RPM spec updated to exclude autodetected osgi requirements

### DIFF
--- a/eucalyptus-java-deps.spec
+++ b/eucalyptus-java-deps.spec
@@ -13,6 +13,9 @@ BuildArch:      noarch
 # usual systemwide locations
 %global __provides_exclude_from ^%{_datadir}/eucalyptus/.*.jar$
 
+# Disable automatic OSGI Requires because we provide all dependencies
+%global __requires_exclude osgi(.*)
+
 Provides:       eucalyptus-java-deps-devel = %{name}-%{release}
 
 


### PR DESCRIPTION
Exclude autodetected osgi requirements so we avoid:

```
# rpm -q --requires eucalyptus-java-deps | grep osgi
osgi(org.apache.xerces)
```

which then means upgrading to 4.4.3 would require:

```
...
Installing for dependencies:
 xalan-j2                                                 noarch                              2.7.1-23.el7                                                   mirror-centos-base                              1.9 M
 xerces-j2                                                noarch                              2.11.0-17.el7_0                                                mirror-centos-base                              1.1 M
 xml-commons-apis                                         noarch                              1.4.01-16.el7                                                  mirror-centos-base                              227 k
 xml-commons-resolver                                     noarch                              1.2-15.el7                                                     mirror-centos-base                              108 k
...
```

and these additional dependencies are not necessary.