### PR TITLE
Fix rpm devel provides version

### DIFF
--- a/eucalyptus-java-deps.spec
+++ b/eucalyptus-java-deps.spec
@@ -16,7 +16,7 @@ BuildArch:      noarch
 # Disable automatic OSGI Requires because we provide all dependencies
 %global __requires_exclude osgi(.*)
 
-Provides:       eucalyptus-java-deps-devel = %{name}-%{release}
+Provides:       eucalyptus-java-deps-devel = %{version}-%{release}
 
 
 %description


### PR DESCRIPTION
The provides metadata for `eucalyptus-java-deps-devel` incorrectly uses the package name rather than the version. This means you end up with:
```
# rpm -q --provides eucalyptus-java-deps
eucalyptus-java-deps = 4.4-1.13.as.el7
eucalyptus-java-deps-devel = eucalyptus-java-deps-1.13.as.el7
```
With the change from this pull request in place you get the correct version/revision provided:
```
# rpm -q --provides eucalyptus-java-deps
eucalyptus-java-deps = 4.4-1.7.testprovide.sj4.el7
eucalyptus-java-deps-devel = 4.4-1.7.testprovide.sj4.el7
```